### PR TITLE
Support g1 (2016-2018) vehicles

### DIFF
--- a/custom_components/subaru/__init__.py
+++ b/custom_components/subaru/__init__.py
@@ -269,7 +269,7 @@ async def subaru_update(vehicle_info, controller):
         data[vin] = await controller.get_data(vin)
 
         # If vehicle pushed bad location then force new update
-        if not data[vin][VEHICLE_STATUS][LOCATION_VALID]:
+        if not data[vin][VEHICLE_STATUS][LOCATION_VALID] and vehicle_info[vin][VEHICLE_HAS_REMOTE_SERVICE]:
             await refresh_subaru_data(vehicle, controller, override_interval=True)
             await controller.fetch(vin, force=True)
             data[vin] = await controller.get_data(vin)

--- a/custom_components/subaru/__init__.py
+++ b/custom_components/subaru/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from subarulink import Controller as SubaruAPI, SubaruException
-from subarulink.const import LOCATION_VALID, VEHICLE_STATUS
+from subarulink.const import FEATURE_G2_TELEMATICS, LOCATION_VALID, VEHICLE_STATUS
 import voluptuous as vol
 
 from .const import (
@@ -268,8 +268,8 @@ async def subaru_update(vehicle_info, controller):
         # Update our local data that will go to entity states
         data[vin] = await controller.get_data(vin)
 
-        # If vehicle pushed bad location then force new update
-        if not data[vin][VEHICLE_STATUS][LOCATION_VALID] and vehicle_info[vin][VEHICLE_HAS_REMOTE_SERVICE]:
+        # If vehicle pushed bad location then force new update (ignore G1 which is always wrong?)
+        if not data[vin][VEHICLE_STATUS][LOCATION_VALID] and vehicle_info[vin][VEHICLE_API_GEN] == FEATURE_G2_TELEMATICS and vehicle_info[vin][VEHICLE_HAS_REMOTE_SERVICE]:
             await refresh_subaru_data(vehicle, controller, override_interval=True)
             await controller.fetch(vin, force=True)
             data[vin] = await controller.get_data(vin)

--- a/custom_components/subaru/manifest.json
+++ b/custom_components/subaru/manifest.json
@@ -3,6 +3,6 @@
   "name": "Subaru",
   "config_flow": true,
   "documentation": "https://github.com/G-Two/homeassistant-subaru",
-  "requirements": ["subarulink==0.3.9"],
+  "requirements": ["subarulink==0.3.10rc0"],
   "codeowners": ["@G-Two"]
 }

--- a/custom_components/subaru/manifest.json
+++ b/custom_components/subaru/manifest.json
@@ -3,6 +3,6 @@
   "name": "Subaru",
   "config_flow": true,
   "documentation": "https://github.com/G-Two/homeassistant-subaru",
-  "requirements": ["subarulink==0.3.10rc0"],
+  "requirements": ["subarulink==0.3.10rc1"],
   "codeowners": ["@G-Two"]
 }

--- a/custom_components/subaru/sensor.py
+++ b/custom_components/subaru/sensor.py
@@ -1,6 +1,4 @@
 """Support for the Subaru sensors."""
-import logging
-
 from homeassistant.const import (
     LENGTH_KILOMETERS,
     LENGTH_MILES,
@@ -79,7 +77,7 @@ API_GEN_2_SENSORS = [
         SENSOR_FIELD: sc.BATTERY_VOLTAGE,
         SENSOR_UNITS: VOLT,
     },
-       {
+    {
         SENSOR_NAME: "Tire Pressure FL",
         SENSOR_FIELD: sc.TIRE_PRESSURE_FL,
         SENSOR_UNITS: PRESSURE_HPA,

--- a/custom_components/subaru/sensor.py
+++ b/custom_components/subaru/sensor.py
@@ -34,7 +34,6 @@ from .const import (
 )
 from .entity import SubaruEntity
 
-_LOGGER = logging.getLogger(__name__)
 L_PER_GAL = vol_convert(1, VOLUME_GALLONS, VOLUME_LITERS)
 KM_PER_MI = dist_convert(1, LENGTH_MILES, LENGTH_KILOMETERS)
 
@@ -47,8 +46,19 @@ SENSOR_NAME = "name"
 SENSOR_FIELD = "field"
 SENSOR_UNITS = "units"
 
-# Sensor data available to "Subaru Safety Plus" subscribers with Gen1 or Gen2 vehicles
+# Sensor data available to "Subaru Safety Plus" subscribers with Gen1/Gen2 vehicles
 SAFETY_SENSORS = [
+    {
+        # Note: For Gen1, this value is only updated every 500 miles.
+        # There is no known manual update method.
+        SENSOR_NAME: "Odometer",
+        SENSOR_FIELD: sc.ODOMETER,
+        SENSOR_UNITS: LENGTH_KILOMETERS,
+    },
+]
+
+# Sensor data available to "Subaru Safety Plus" subscribers with Gen2 vehicles
+API_GEN_2_SENSORS = [
     {
         SENSOR_NAME: "Avg Fuel Consumption",
         SENSOR_FIELD: sc.AVG_FUEL_CONSUMPTION,
@@ -60,11 +70,16 @@ SAFETY_SENSORS = [
         SENSOR_UNITS: LENGTH_KILOMETERS,
     },
     {
-        SENSOR_NAME: "Odometer",
-        SENSOR_FIELD: sc.ODOMETER,
-        SENSOR_UNITS: LENGTH_KILOMETERS,
+        SENSOR_NAME: "External Temp",
+        SENSOR_FIELD: sc.EXTERNAL_TEMP,
+        SENSOR_UNITS: TEMP_CELSIUS,
     },
     {
+        SENSOR_NAME: "12V Battery Voltage",
+        SENSOR_FIELD: sc.BATTERY_VOLTAGE,
+        SENSOR_UNITS: VOLT,
+    },
+       {
         SENSOR_NAME: "Tire Pressure FL",
         SENSOR_FIELD: sc.TIRE_PRESSURE_FL,
         SENSOR_UNITS: PRESSURE_HPA,
@@ -83,20 +98,6 @@ SAFETY_SENSORS = [
         SENSOR_NAME: "Tire Pressure RR",
         SENSOR_FIELD: sc.TIRE_PRESSURE_RR,
         SENSOR_UNITS: PRESSURE_HPA,
-    },
-]
-
-# Sensor data available to "Subaru Safety Plus" subscribers with Gen2 vehicles
-API_GEN_2_SENSORS = [
-    {
-        SENSOR_NAME: "External Temp",
-        SENSOR_FIELD: sc.EXTERNAL_TEMP,
-        SENSOR_UNITS: TEMP_CELSIUS,
-    },
-    {
-        SENSOR_NAME: "12V Battery Voltage",
-        SENSOR_FIELD: sc.BATTERY_VOLTAGE,
-        SENSOR_UNITS: VOLT,
     },
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ ignore =
     E203,
     D202,
     W504
+per-file-ignores =
+    tests/*.py:F401,F811
 
 [isort]
 # https://github.com/timothycrosley/isort

--- a/tests/common.py
+++ b/tests/common.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.setup import async_setup_component
+import pytest
 from pytest_homeassistant_custom_component.async_mock import patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from subarulink import InvalidCredentials
@@ -25,6 +26,8 @@ from custom_components.subaru.const import (
     VEHICLE_HAS_SAFETY_SERVICE,
     VEHICLE_NAME,
 )
+
+from tests.api_responses import TEST_VIN_2_EV, VEHICLE_DATA, VEHICLE_STATUS_EV
 
 TEST_CONFIG = {
     CONF_USERNAME: "user",
@@ -88,8 +91,21 @@ async def setup_subaru_integration(
         "custom_components.subaru.SubaruAPI.fetch",
     ):
         success = await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     if success:
         return config_entry
     return None
+
+
+@pytest.fixture
+async def ev_entry(hass):
+    """Create a Subaru entity representing an EV vehicle with full STARLINK subscription."""
+    entry = await setup_subaru_integration(
+        hass,
+        vehicle_list=[TEST_VIN_2_EV],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
+        vehicle_status=VEHICLE_STATUS_EV,
+    )
+    assert hass.data[DOMAIN][entry.entry_id]
+    return entry

--- a/tests/common.py
+++ b/tests/common.py
@@ -100,7 +100,7 @@ async def setup_subaru_integration(
 
 @pytest.fixture
 async def ev_entry(hass):
-    """Create a Subaru entity representing an EV vehicle with full STARLINK subscription."""
+    """Create a Subaru entry representing an EV vehicle with full STARLINK subscription."""
     entry = await setup_subaru_integration(
         hass,
         vehicle_list=[TEST_VIN_2_EV],

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -2,31 +2,23 @@
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
 from pytest_homeassistant_custom_component.async_mock import patch
 
-from .api_responses import TEST_VIN_2_EV, VEHICLE_DATA, VEHICLE_STATUS_EV
-from .common import setup_subaru_integration
+from .common import ev_entry
 
 DEVICE_ID = "lock.test_vehicle_2_door_lock"
 
 
-async def test_device_exists(hass):
+async def test_device_exists(hass, ev_entry):
     """Test subaru lock entity exists."""
-    await _setup_ev(hass, unit_system=IMPERIAL_SYSTEM)
-
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry
 
 
-async def test_lock(hass):
+async def test_lock(hass, ev_entry):
     """Test subaru lock function."""
-    with patch(
-        "custom_components.subaru.SubaruAPI.get_data", return_value=VEHICLE_STATUS_EV,
-    ), patch("custom_components.subaru.SubaruAPI.lock",) as mock_lock:
-        await _setup_ev(hass, unit_system=IMPERIAL_SYSTEM)
-
+    with patch("custom_components.subaru.SubaruAPI.lock",) as mock_lock:
         await hass.services.async_call(
             LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
@@ -34,25 +26,11 @@ async def test_lock(hass):
         mock_lock.assert_called_once()
 
 
-async def test_unlock(hass):
+async def test_unlock(hass, ev_entry):
     """Test subaru unlock function."""
-    with patch(
-        "custom_components.subaru.SubaruAPI.get_data", return_value=VEHICLE_STATUS_EV,
-    ), patch("custom_components.subaru.SubaruAPI.unlock",) as mock_unlock:
-        await _setup_ev(hass, unit_system=IMPERIAL_SYSTEM)
-
+    with patch("custom_components.subaru.SubaruAPI.unlock",) as mock_unlock:
         await hass.services.async_call(
             LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
         )
         await hass.async_block_till_done()
         mock_unlock.assert_called_once()
-
-
-async def _setup_ev(hass, unit_system=METRIC_SYSTEM):
-    hass.config.units = unit_system
-    return await setup_subaru_integration(
-        hass,
-        vehicle_list=[TEST_VIN_2_EV],
-        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
-        vehicle_status=VEHICLE_STATUS_EV,
-    )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,10 +1,10 @@
 """Test Subaru sensors."""
 
 from homeassistant.util import slugify
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 from pytest_homeassistant_custom_component.async_mock import patch
 
-from custom_components.subaru.const import VEHICLE_NAME
+from custom_components.subaru.const import DOMAIN, ENTRY_COORDINATOR, VEHICLE_NAME
 from custom_components.subaru.sensor import (
     API_GEN_2_SENSORS,
     EV_SENSORS,
@@ -20,65 +20,39 @@ from .api_responses import (
     VEHICLE_DATA,
     VEHICLE_STATUS_EV,
 )
-from .common import setup_subaru_integration
+from .common import ev_entry
+
+VEHICLE_NAME = VEHICLE_DATA[TEST_VIN_2_EV][VEHICLE_NAME]
 
 
-async def test_sensors_ev_imperial(hass):
+async def test_sensors_ev_imperial(hass, ev_entry):
     """Test sensors supporting imperial units."""
     with patch("custom_components.subaru.SubaruAPI.fetch"), patch(
         "custom_components.subaru.SubaruAPI.get_data", return_value=VEHICLE_STATUS_EV,
     ):
-        await _setup_ev(hass, unit_system=IMPERIAL_SYSTEM)
+        hass.config.units = IMPERIAL_SYSTEM
+        coordinator = hass.data[DOMAIN][ev_entry.entry_id][ENTRY_COORDINATOR]
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
 
-        sensor_list = EV_SENSORS
-        sensor_list.extend(API_GEN_2_SENSORS)
-        sensor_list.extend(SAFETY_SENSORS)
-        expected = _get_expected(
-            VEHICLE_DATA[TEST_VIN_2_EV][VEHICLE_NAME],
-            sensor_list,
-            EXPECTED_STATE_EV_IMPERIAL,
-        )
-
-        for sensor in expected:
-            actual = hass.states.get(sensor)
-            assert actual.state == expected[sensor]
+    _assert_data(hass, EXPECTED_STATE_EV_IMPERIAL)
 
 
-async def test_sensors_ev_metric(hass):
+async def test_sensors_ev_metric(hass, ev_entry):
     """Test sensors supporting metric units."""
-    with patch("custom_components.subaru.SubaruAPI.fetch"), patch(
-        "custom_components.subaru.SubaruAPI.get_data", return_value=VEHICLE_STATUS_EV,
-    ):
-        await _setup_ev(hass)
-
-        sensor_list = EV_SENSORS
-        sensor_list.extend(API_GEN_2_SENSORS)
-        sensor_list.extend(SAFETY_SENSORS)
-        expected = _get_expected(
-            VEHICLE_DATA[TEST_VIN_2_EV][VEHICLE_NAME],
-            sensor_list,
-            EXPECTED_STATE_EV_METRIC,
-        )
-
-        for sensor in expected:
-            actual = hass.states.get(sensor)
-            assert actual.state == expected[sensor]
+    _assert_data(hass, EXPECTED_STATE_EV_METRIC)
 
 
-def _get_expected(vehicle_name, sensor_list, expected_state):
-    expected = {}
+def _assert_data(hass, expected_state):
+    sensor_list = EV_SENSORS
+    sensor_list.extend(API_GEN_2_SENSORS)
+    sensor_list.extend(SAFETY_SENSORS)
+    expected_states = {}
     for item in sensor_list:
-        expected[
-            f"sensor.{slugify(f'{vehicle_name} {item[SENSOR_NAME]}')}"
+        expected_states[
+            f"sensor.{slugify(f'{VEHICLE_NAME} {item[SENSOR_NAME]}')}"
         ] = expected_state[item[SENSOR_FIELD]]
-    return expected
 
-
-async def _setup_ev(hass, unit_system=METRIC_SYSTEM):
-    hass.config.units = unit_system
-    return await setup_subaru_integration(
-        hass,
-        vehicle_list=[TEST_VIN_2_EV],
-        vehicle_data=VEHICLE_DATA[TEST_VIN_2_EV],
-        vehicle_status=VEHICLE_STATUS_EV,
-    )
+    for sensor in expected_states:
+        actual = hass.states.get(sensor)
+        assert actual.state == expected_states[sensor]


### PR DESCRIPTION
Add support for g1 vehicles.  Functionality is limited compared to g2 (2019+) vehicles.

Sensor:
- Odometer: Only updates every 500 miles, when the vehicles decides to send an update.  It would be great to find a way to force an update.

Lock:
- Functions the same as g2

Device Tracker:
- Functions the same as g2

Services:
- Lock/Unlock - same as g2
- Lights/Horn - same as g2
- Update (Locate) - same as g2

Known issues:
- 2 hours after initial login with a g1 vehicle, calling `switchVehicle.json` to the g1 vehicle will  result in a `"VEHICLESETUPERROR"`, and remote services stop working.  The `subarulink` module handles this gracefully by resetting the session cookie and logging on again.  I have it set to log a `subarulink` warning for now, so I can track if it becomes problematic.
- Binary Sensors take >10 seconds to initialize when a g2 and g1 vehicle are on the same account. 