### PR TITLE
v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ Users that desire full functionality should continue to use this custom componen
 
 ***
 
+* [Description](#description)
+* [Installation](#installation)
+  * [HACS](#hacs)
+  * [Manual](#manual)
+* [Configuration](#configuration)
+* [Options](#options)
+* [Services](#services)
+* [Lovelace Example](#lovelace-example)
+
+## Description
 The Subaru integration retrieves information provided by Subaru connected vehicle services.  Before using this integration, you must first register and have login credentials to [MySubaru](https://www.mysubaru.com).
 
 This integration requires an active vehicle subscription to the [Subaru STARLINK](https://www.subaru.com/engineering/starlink/safety-security.html) service (available in USA and Canada).
-
-![hass_screenshot](https://user-images.githubusercontent.com/7310260/102023873-50fd5f80-3d5c-11eb-93ca-4b2bb6f27e92.png)
-
 
 Subaru has deployed two generations of telematics, Gen 1 and Gen 2. Use the tables below to determine which capabilities are available for your vehicle.
 
@@ -111,79 +118,402 @@ Subaru integration options are set via:
 
 **Configuration** -> **Integrations** -> **Subaru (HACS)** -> **Options**.
 
-The options are:
+All options involve remote commands, thus only apply to vehicles with Security Plus subscriptions:
 
-- **Enable vehicle polling *[Default: off]*:**  When enabled, vehicle polling will send a remote command to your vehicle every 2 hours to obtain new sensor data. This involves “waking” your vehicle and requesting that it send new data to Subaru servers. Without vehicle polling, new sensor data is only received when the vehicle automatically pushes data (normally after engine shutdown). This option only applies to vehicles with Security Plus subscriptions.
+- **Enable vehicle polling:**  Sensor data reported by the Subaru API only returns what is cached on Subaru servers, and does not necessarily reflect current conditions. The cached data is updated when the engine is shutdown, or when a location update is requested. This options enables automatic periodic updates.
+  - **Disabled *[Default]*:** New sensor data is only received when the vehicle automatically pushes data (normally after engine shutdown). The user may still manually poll the vehicle anytime with the `subaru.update` service.
+  - **Enabled:** Every 2 hours, the integration will send a remote command (equivalent to running the `subaru.update` service), "waking" your vehicle obtain new sensor data. *WARNING:* Vehicle polling draws power from the 12V battery. Long term use without driving may drain the battery resulting in the inability to start your vehicle.
 
-    **WARNING:** Vehicle polling draws power from the 12V battery. Long term use without driving may drain the battery resulting in the inability to start your vehicle.
-
-- **Enable persistent notifications for remote commands *[Default: off]*:**  It takes 10-15 seconds for remote commands to be processed and transmitted over the cellular network to your vehicle. This integration will produce a notification in Lovelace while the remote command is pending completion to inform the user that the command is "working" and will disappear upon success. When this option is enabled, the integration will persist a success notification in Lovelace until it is manually dismissed. Any failures will always result in a persistent notification, regardless of this option.
+- **Lovelace UI notifications for remote commands:**  It takes 10-15 seconds for remote commands to be processed by the Subaru API and transmitted over the cellular network to your vehicle. Some users may desire UI feedback that the integration is working. This option provides three levels of increasing verbosity:
+  - **Failure *[Default]*:** Only notify when the remote command has failed.
+  - **Pending:** Failure + temporary notification that the command is "working" that will automatically disappear when the Subaru API confirms success (10 to 15 seconds).
+  - **Success:** Pending + persistent notification in Lovelace. This is the same behavior as v0.5.1 and earlier releases.
 
 ## Services
 
-**NOTE:** Subaru lock uses the services provided by the Home Assistant [Lock](https://www.home-assistant.io/integrations/lock/) integration
+Services provided by this integration are shown below:
+**NOTE:** Subaru lock uses the services provided by the built-in Home Assistant [Lock](https://www.home-assistant.io/integrations/lock/) platform
 
-### `subaru.lights`
-Flash the lights of the vehicle. The vehicle is identified by the `vin`.
+| Service                | Description |
+| ---------------------- | ----------- |
+|`subaru.charge_start`   | Starts EV charging (this cannot be stopped remotely) |
+|`subaru.fetch`          | Fetches vehicle data cached on Subaru servers (does not request update from vehicle) |
+|`subaru.horn`           | Sound the horn and flash the lights of the vehicle |
+|`subaru.horn_cancel`    | Stop sounding the horn and flash the lights of the vehicle |
+|`subaru.lights`         | Flash the lights of the vehicle |
+|`subaru.lights_cancel`  | Stop flashing the lights of the vehicle |
+|`subaru.remote_start`   | Start the engine and climate control of the vehicle using the most recent climate control settings |
+|`subaru.remote_stop`    | Stop the engine and climate control of the vehicle |
+|`subaru.update`         | Sends request to vehicle to update data which will update cache on Subaru servers |
 
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
-
-### `subaru.lights_cancel`
-Stop flashing the lights of the vehicle. The vehicle is identified by the `vin`.
-
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
-
-### `subaru.horn`
-Sound the horn and flash the lights of the vehicle. The vehicle is identified by the `vin`.
+All of the above services require the same service data attribute shown below. The service will be invoked on the vehicle identified by `vin`.
 
 | Service Data Attribute | Required | Description                                        |
 | ---------------------- | -------- | -------------------------------------------------- |
 | `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
 
-### `subaru.horn_cancel`
-Stop sounding the horn and flash the lights of the vehicle. The vehicle is identified by the `vin`.
+## Lovelace Example
 
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
+![hass_screenshot](https://user-images.githubusercontent.com/7310260/146694159-ba5da7b1-ec66-4fe5-91a5-2351c2783a34.png)
 
-### `subaru.update`
-Sends request to vehicle to update data. The vehicle is identified by the `vin`.
+<details><summary>Example Lovelace YAML</summary>
+<p>
 
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
+```yaml
+# Example YAML for the dashboard shown above. Replace entity names and VIN with your vehicle info.
+title: Home
+views:
+  - badges: []
+    cards:
+      - cards:
+          - entity: sensor.subaru_odometer
+            name: Odometer
+            type: entity
+          - entity: sensor.subaru_avg_fuel_consumption
+            name: Avg Fuel Consumption
+            type: entity
+          - entity: sensor.subaru_range
+            name: Distance to Empty
+            type: entity
+        type: vertical-stack
+        title: Mileage
+      - cards:
+          - cards:
+              - entity: sensor.subaru_tire_pressure_fl
+                max: 38
+                min: 24
+                name: FL
+                severity:
+                  green: 36
+                  red: 2
+                  yellow: 32
+                type: gauge
+                needle: true
+              - entity: sensor.subaru_tire_pressure_fr
+                name: FR
+                severity:
+                  green: 36
+                  red: 0
+                  yellow: 32
+                type: gauge
+                needle: true
+                min: 24
+                max: 38
+            type: horizontal-stack
+          - cards:
+              - entity: sensor.subaru_tire_pressure_rl
+                name: RL
+                type: gauge
+                needle: true
+                min: 24
+                severity:
+                  green: 36
+                  yellow: 32
+                  red: 0
+                max: 38
+              - entity: sensor.subaru_tire_pressure_rr
+                name: RR
+                severity:
+                  green: 36
+                  red: 0
+                  yellow: 32
+                type: gauge
+                needle: true
+                min: 24
+                max: 38
+            type: horizontal-stack
+        type: vertical-stack
+        title: Tire Pressure
+      - type: vertical-stack
+        cards:
+          - type: horizontal-stack
+            cards:
+              - entity: ''
+                hold_action:
+                  action: more-info
+                icon: mdi:refresh
+                icon_height: 32px
+                name: Refresh
+                show_icon: true
+                show_name: true
+                show_state: false
+                tap_action:
+                  action: call-service
+                  service: subaru.fetch
+                  service_data:
+                    vin: <REPLACE_WITH_VIN>
+                type: button
+              - entity: ''
+                hold_action:
+                  action: more-info
+                icon: mdi:car-connected
+                icon_height: 32px
+                name: Poll Vehicle
+                show_icon: true
+                show_name: true
+                show_state: false
+                tap_action:
+                  action: call-service
+                  confirmation:
+                    text: Poll Vehicle?
+                  service: subaru.update
+                  service_data:
+                    vin: <REPLACE_WITH_VIN>
+                type: button
+            title: Update Data
+          - type: vertical-stack
+            title: Remote Commands
+            cards:
+              - cards:
+                  - icon: mdi:lock
+                    icon_height: 32px
+                    name: Lock
+                    show_icon: true
+                    show_name: true
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Lock Doors?
+                      service: lock.lock
+                      service_data: {}
+                      target:
+                        entity_id: lock.subaru_door_lock
+                    type: button
+                  - entity: ''
+                    icon: mdi:lock-open-variant
+                    icon_height: 32px
+                    name: Unlock
+                    show_icon: true
+                    show_name: true
+                    show_state: false
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Unlock Doors?
+                      service: lock.unlock
+                      service_data: {}
+                      target:
+                        entity_id: lock.subaru_door_lock
+                    type: button
+                type: horizontal-stack
+              - cards:
+                  - entity: ''
+                    hold_action:
+                      action: more-info
+                    icon: mdi:lightbulb-on
+                    icon_height: 32px
+                    name: Flash Lights
+                    show_icon: true
+                    show_name: true
+                    show_state: false
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Flash lights?
+                      service: subaru.lights
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                    type: button
+                  - entity: ''
+                    hold_action:
+                      action: more-info
+                    icon_height: 32px
+                    icon: mdi:lightbulb-off
+                    name: Stop Lights
+                    show_icon: true
+                    show_name: true
+                    show_state: false
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Stop lights?
+                      service: subaru.lights_stop
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                    type: button
+                type: horizontal-stack
+              - cards:
+                  - entity: ''
+                    hold_action:
+                      action: more-info
+                    icon: mdi:volume-high
+                    icon_height: 32px
+                    name: Sound Horn
+                    show_icon: true
+                    show_name: true
+                    show_state: false
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Sound horn?
+                      service: subaru.horn
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                    type: button
+                  - entity: ''
+                    hold_action:
+                      action: more-info
+                    icon_height: 32px
+                    icon: mdi:volume-off
+                    name: Stop Horn
+                    show_icon: true
+                    show_name: true
+                    show_state: false
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Stop horn?
+                      service: subaru.horn_stop
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                    type: button
+                type: horizontal-stack
+              - cards:
+                  - type: button
+                    hold_action:
+                      action: more-info
+                    icon: mdi:power
+                    icon_height: 32px
+                    name: Remote Start
+                    show_icon: true
+                    show_name: true
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Remote Start?
+                      service: subaru.remote_start
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                  - entity: ''
+                    hold_action:
+                      action: more-info
+                    icon: mdi:stop
+                    icon_height: 32px
+                    name: Remote Stop
+                    show_icon: true
+                    show_name: true
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Remote Stop?
+                      service: subaru.remote_stop
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                    type: button
+                type: horizontal-stack
+          - cards:
+              - cards:
+                  - entity: ''
+                    hold_action:
+                      action: more-info
+                    icon: mdi:battery-charging
+                    icon_height: 32px
+                    name: Begin Charging
+                    show_icon: true
+                    show_name: true
+                    show_state: false
+                    tap_action:
+                      action: call-service
+                      confirmation:
+                        text: Begin Charging?
+                      service: subaru.charge_start
+                      service_data:
+                        vin: <REPLACE_WITH_VIN>
+                    type: button
+                  - entity: sensor.subaru_ev_battery_level
+                    name: EV Battery Level
+                    type: entity
+                type: horizontal-stack
+              - type: vertical-stack
+                cards:
+                  - type: horizontal-stack
+                    cards:
+                      - type: entity
+                        entity: binary_sensor.subaru_ev_charge_port
+                        name: Plugged In
+                      - type: conditional
+                        conditions:
+                          - entity: sensor.subaru_ev_time_to_full_charge
+                            state_not: '1970-01-01T00:00:00'
+                        card:
+                          type: markdown
+                          content: >
+                            {% set time =
+                            (as_timestamp(states.sensor.subaru_ev_time_to_full_charge.state)
+                            - as_timestamp(now())) %}
 
-### `subaru.fetch`
-Refreshes data (does not request update from vehicle). The vehicle is identified by the `vin`.
+                            {% set hours = time // 3600 %}
 
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
+                            {% set minutes = time // 60 % 60 %}
 
-### `subaru.remote_start`
-Start the engine and climate control of the vehicle.  Uses the climate control settings saved. The vehicle is identified by the `vin`.
+                            {% if int(hours) > 0 %}
 
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
-
-### `subaru.remote_stop`
-Stop the engine and climate control of the vehicle. The vehicle is identified by the `vin`.
-
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
-
-### `subaru.charge_start`
-Starts EV charging. This cannot be stopped remotely. The vehicle is identified by the `vin`.
-
-| Service Data Attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `vin`                  |   yes    | The vehicle identification number (VIN) of the vehicle, 17 characters |
-
-
+                            {{ int(hours) }} hours {% endif %}{{ int(minutes) }}
+                            minutes
+                          title: Time to Full Charge
+            type: vertical-stack
+            title: EV Functions
+      - type: vertical-stack
+        cards:
+          - detail: -2
+            entity: sensor.subaru_12v_battery_voltage
+            graph: line
+            name: Auxiliary Battery
+            type: sensor
+          - entity: sensor.subaru_external_temp
+            graph: line
+            name: External Temp
+            type: sensor
+          - type: entity
+            entity: binary_sensor.subaru_ignition
+            name: Subaru Ignition
+        title: Miscellaneous Data
+      - card:
+          type: glance
+          title: Door(s) Open
+        type: entity-filter
+        entities:
+          - entity: binary_sensor.subaru_front_left_door
+            name: FL Door
+            show_state: false
+            show_icon: false
+            icon: None
+          - entity: binary_sensor.subaru_hood
+            name: Hood
+            show_state: false
+            show_icon: false
+            icon: None
+          - entity: binary_sensor.subaru_front_right_door
+            name: FR Door
+            show_state: false
+            show_icon: false
+            icon: None
+          - entity: binary_sensor.subaru_rear_left_door
+            name: RL Door
+            show_state: false
+            show_icon: false
+            icon: None
+          - entity: binary_sensor.subaru_trunk
+            name: Trunk
+            show_state: false
+            show_icon: false
+            icon: None
+          - entity: binary_sensor.subaru_rear_right_door
+            name: RR Door
+            show_state: false
+            show_icon: false
+            icon: None
+        state_filter:
+          - 'on'
+        show_empty: false
+      - type: map
+        entities:
+          - entity: device_tracker.subaru_location
+        hours_to_show: 0
+        title: Subaru Location
+        default_zoom: 14
+    icon: ''
+    title: Subaru
+```
+</p>
+</details>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ The options are:
 
 - **Enable vehicle polling *[Default: off]*:**  When enabled, vehicle polling will send a remote command to your vehicle every 2 hours to obtain new sensor data. This involves “waking” your vehicle and requesting that it send new data to Subaru servers. Without vehicle polling, new sensor data is only received when the vehicle automatically pushes data (normally after engine shutdown). This option only applies to vehicles with Security Plus subscriptions.
 
-    **WARNING:** Vehicle polling draws power from the 12V battery. Long term use without driving may drain the battery resulting in the inability to start.
+    **WARNING:** Vehicle polling draws power from the 12V battery. Long term use without driving may drain the battery resulting in the inability to start your vehicle.
+
+- **Enable persistent notifications for remote commands *[Default: off]*:**  It takes 10-15 seconds for remote commands to be processed and transmitted over the cellular network to your vehicle. This integration will produce a notification in Lovelace while the remote command is pending completion to inform the user that the command is "working" and will disappear upon success. When this option is enabled, the integration will persist a success notification in Lovelace until it is manually dismissed. Any failures will always result in a persistent notification, regardless of this option.
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Device tracker, lock, and services all require a STARLINK Security Plus subscrip
 
 ## Installation
 ### HACS
-Add `https://github.com/G-Two/homeassistant-subaru` as a custom integration repository and install the Subaru STARLINK integration.
+Add `https://github.com/G-Two/homeassistant-subaru` as a custom integration repository and install the **Subaru (HACS)** integration.
 ### Manual
 Clone or download this repository, and copy the `custom_components/subaru` directory into the `config/custom_components` directory of your Home Assistant instance. Restart Home Assistant.
 
@@ -127,11 +127,12 @@ All options involve remote commands, thus only apply to vehicles with Security P
 - **Lovelace UI notifications for remote commands:**  It takes 10-15 seconds for remote commands to be processed by the Subaru API and transmitted over the cellular network to your vehicle. Some users may desire UI feedback that the integration is working. This option provides three levels of increasing verbosity:
   - **Failure *[Default]*:** Only notify when the remote command has failed.
   - **Pending:** Failure + temporary notification that the command is "working" that will automatically disappear when the Subaru API confirms success (10 to 15 seconds).
-  - **Success:** Pending + persistent notification in Lovelace. This is the same behavior as v0.5.1 and earlier releases.
+  - **Success:** Pending + persistent notification of success in Lovelace. This is the same behavior as v0.5.1 and earlier releases.
 
 ## Services
 
 Services provided by this integration are shown below:
+
 **NOTE:** Subaru lock uses the services provided by the built-in Home Assistant [Lock](https://www.home-assistant.io/integrations/lock/) platform
 
 | Service                | Description |

--- a/custom_components/subaru/__init__.py
+++ b/custom_components/subaru/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     CONF_COUNTRY,
+    CONF_PERSISTENT_NOTIFICATIONS,
     CONF_UPDATE_ENABLED,
     COORDINATOR_NAME,
     DOMAIN,
@@ -122,7 +123,11 @@ async def async_setup_entry(hass, entry):
         if vin in vehicles:
             if call.service != REMOTE_SERVICE_FETCH:
                 await async_call_remote_service(
-                    hass, controller, call.service, vehicles[vin]
+                    hass,
+                    controller,
+                    call.service,
+                    vehicles[vin],
+                    entry.options.get(CONF_PERSISTENT_NOTIFICATIONS),
                 )
             if call.service in SERVICES_THAT_NEED_FETCH:
                 await coordinator.async_refresh()

--- a/custom_components/subaru/__init__.py
+++ b/custom_components/subaru/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     CONF_COUNTRY,
-    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_NOTIFICATION_OPTION,
     CONF_UPDATE_ENABLED,
     COORDINATOR_NAME,
     DOMAIN,
@@ -127,7 +127,7 @@ async def async_setup_entry(hass, entry):
                     controller,
                     call.service,
                     vehicles[vin],
-                    entry.options.get(CONF_PERSISTENT_NOTIFICATIONS),
+                    entry.options.get(CONF_NOTIFICATION_OPTION),
                 )
             if call.service in SERVICES_THAT_NEED_FETCH:
                 await coordinator.async_refresh()

--- a/custom_components/subaru/config_flow.py
+++ b/custom_components/subaru/config_flow.py
@@ -16,7 +16,12 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_PASSWORD, CONF_PIN, CONF_US
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import CONF_COUNTRY, CONF_UPDATE_ENABLED, DOMAIN
+from .const import (
+    CONF_COUNTRY,
+    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_UPDATE_ENABLED,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,6 +155,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(
                     CONF_UPDATE_ENABLED,
                     default=self.config_entry.options.get(CONF_UPDATE_ENABLED, False),
+                ): cv.boolean,
+                vol.Required(
+                    CONF_PERSISTENT_NOTIFICATIONS,
+                    default=self.config_entry.options.get(
+                        CONF_PERSISTENT_NOTIFICATIONS, False
+                    ),
                 ): cv.boolean,
             }
         )

--- a/custom_components/subaru/config_flow.py
+++ b/custom_components/subaru/config_flow.py
@@ -18,9 +18,10 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 from .const import (
     CONF_COUNTRY,
-    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_NOTIFICATION_OPTION,
     CONF_UPDATE_ENABLED,
     DOMAIN,
+    NotificationOptions,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -157,11 +158,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     default=self.config_entry.options.get(CONF_UPDATE_ENABLED, False),
                 ): cv.boolean,
                 vol.Required(
-                    CONF_PERSISTENT_NOTIFICATIONS,
+                    CONF_NOTIFICATION_OPTION,
                     default=self.config_entry.options.get(
-                        CONF_PERSISTENT_NOTIFICATIONS, False
+                        CONF_NOTIFICATION_OPTION, NotificationOptions.FAILURE.value
                     ),
-                ): cv.boolean,
+                ): vol.In(sorted(NotificationOptions.list())),
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/subaru/const.py
+++ b/custom_components/subaru/const.py
@@ -1,9 +1,11 @@
 """Constants for the Subaru integration."""
+from homeassistant.const import Platform
 
 DOMAIN = "subaru"
 FETCH_INTERVAL = 300
 UPDATE_INTERVAL = 7200
 CONF_UPDATE_ENABLED = "update_enabled"
+CONF_PERSISTENT_NOTIFICATIONS = "persistent_notifications"
 CONF_COUNTRY = "country"
 
 # entry fields
@@ -43,10 +45,10 @@ REMOTE_SERVICE_REMOTE_STOP = "remote_stop"
 REMOTE_SERVICE_CHARGE_START = "charge_start"
 
 SUPPORTED_PLATFORMS = [
-    "binary_sensor",
-    "device_tracker",
-    "lock",
-    "sensor",
+    Platform.BINARY_SENSOR,
+    Platform.DEVICE_TRACKER,
+    Platform.LOCK,
+    Platform.SENSOR,
 ]
 
 ICONS = {

--- a/custom_components/subaru/const.py
+++ b/custom_components/subaru/const.py
@@ -1,12 +1,35 @@
 """Constants for the Subaru integration."""
+from enum import Enum
+
 from homeassistant.const import Platform
 
 DOMAIN = "subaru"
 FETCH_INTERVAL = 300
 UPDATE_INTERVAL = 7200
 CONF_UPDATE_ENABLED = "update_enabled"
-CONF_PERSISTENT_NOTIFICATIONS = "persistent_notifications"
+CONF_NOTIFICATION_OPTION = "notification_option"
 CONF_COUNTRY = "country"
+
+
+class NotificationOptions(Enum):
+    """Lovelace levels of notification."""
+
+    FAILURE = "Failure — Only notify on failure"
+    PENDING = "Pending — Temporary notification of remote command in progress"
+    SUCCESS = "Success — Persistent notification of completed remote command"
+
+    @classmethod
+    def list(cls):
+        """List values of NotificationOptions."""
+        return [item.value for item in NotificationOptions]
+
+    @classmethod
+    def get_by_value(cls, value):
+        """Get enum instance by value."""
+        for item in cls:
+            if item.value == value:
+                return item
+
 
 # entry fields
 ENTRY_CONTROLLER = "controller"

--- a/custom_components/subaru/lock.py
+++ b/custom_components/subaru/lock.py
@@ -6,7 +6,7 @@ from homeassistant.const import SERVICE_LOCK, SERVICE_UNLOCK
 
 from . import DOMAIN as SUBARU_DOMAIN
 from .const import (
-    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_NOTIFICATION_OPTION,
     ENTRY_CONTROLLER,
     ENTRY_COORDINATOR,
     ENTRY_VEHICLES,
@@ -54,7 +54,7 @@ class SubaruLock(SubaruEntity, LockEntity):
             self.controller,
             SERVICE_LOCK,
             self.vehicle_info,
-            self.config_entry.options.get(CONF_PERSISTENT_NOTIFICATIONS),
+            self.config_entry.options.get(CONF_NOTIFICATION_OPTION),
         )
 
     async def async_unlock(self, **kwargs):
@@ -65,5 +65,5 @@ class SubaruLock(SubaruEntity, LockEntity):
             self.controller,
             SERVICE_UNLOCK,
             self.vehicle_info,
-            self.config_entry.options.get(CONF_PERSISTENT_NOTIFICATIONS),
+            self.config_entry.options.get(CONF_NOTIFICATION_OPTION),
         )

--- a/custom_components/subaru/lock.py
+++ b/custom_components/subaru/lock.py
@@ -6,6 +6,7 @@ from homeassistant.const import SERVICE_LOCK, SERVICE_UNLOCK
 
 from . import DOMAIN as SUBARU_DOMAIN
 from .const import (
+    CONF_PERSISTENT_NOTIFICATIONS,
     ENTRY_CONTROLLER,
     ENTRY_COORDINATOR,
     ENTRY_VEHICLES,
@@ -25,7 +26,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entities = []
     for vehicle in vehicle_info.values():
         if vehicle[VEHICLE_HAS_REMOTE_SERVICE]:
-            entities.append(SubaruLock(vehicle, coordinator, controller))
+            entities.append(SubaruLock(vehicle, coordinator, controller, config_entry))
     async_add_entities(entities, True)
 
 
@@ -37,23 +38,32 @@ class SubaruLock(SubaruEntity, LockEntity):
     Lock status is always unknown.
     """
 
-    def __init__(self, vehicle_info, coordinator, controller):
+    def __init__(self, vehicle_info, coordinator, controller, config_entry):
         """Initialize the locks for the vehicle."""
         super().__init__(vehicle_info, coordinator)
         self.entity_type = "Door Lock"
         self.hass_type = LOCK_DOMAIN
         self.controller = controller
+        self.config_entry = config_entry
 
     async def async_lock(self, **kwargs):
         """Send the lock command."""
         _LOGGER.debug("Locking doors for: %s", self.vin)
         await async_call_remote_service(
-            self.hass, self.controller, SERVICE_LOCK, self.vehicle_info
+            self.hass,
+            self.controller,
+            SERVICE_LOCK,
+            self.vehicle_info,
+            self.config_entry.options.get(CONF_PERSISTENT_NOTIFICATIONS),
         )
 
     async def async_unlock(self, **kwargs):
         """Send the unlock command."""
         _LOGGER.debug("Unlocking doors for: %s", self.vin)
         await async_call_remote_service(
-            self.hass, self.controller, SERVICE_UNLOCK, self.vehicle_info
+            self.hass,
+            self.controller,
+            SERVICE_UNLOCK,
+            self.vehicle_info,
+            self.config_entry.options.get(CONF_PERSISTENT_NOTIFICATIONS),
         )

--- a/custom_components/subaru/manifest.json
+++ b/custom_components/subaru/manifest.json
@@ -4,8 +4,8 @@
   "config_flow": true,
   "documentation": "https://github.com/G-Two/homeassistant-subaru",
   "issue_tracker": "https://github.com/G-Two/homeassistant-subaru/issues",
-  "requirements": ["subarulink==0.3.15"],
+  "requirements": ["subarulink==0.3.16"],
   "codeowners": ["@G-Two"],
-  "version": "0.5.0",
+  "version": "0.5.2",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/subaru/remote_service.py
+++ b/custom_components/subaru/remote_service.py
@@ -25,6 +25,7 @@ from .const import (
     VEHICLE_LAST_UPDATE,
     VEHICLE_NAME,
     VEHICLE_VIN,
+    NotificationOptions,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,17 +39,17 @@ SERVICES_THAT_NEED_FETCH = [
 ]
 
 
-async def async_call_remote_service(
-    hass, controller, cmd, vehicle_info, persist_notification
-):
+async def async_call_remote_service(hass, controller, cmd, vehicle_info, notify_option):
     """Execute subarulink remote command with start/end notification."""
     car_name = vehicle_info[VEHICLE_NAME]
     vin = vehicle_info[VEHICLE_VIN]
-    hass.components.persistent_notification.create(
-        f"Sending {cmd} command to {car_name}\nThis may take 10-15 seconds",
-        "Subaru",
-        DOMAIN,
-    )
+    notify = NotificationOptions.get_by_value(notify_option)
+    if notify in [NotificationOptions.PENDING, NotificationOptions.SUCCESS]:
+        hass.components.persistent_notification.create(
+            f"Sending {cmd} command to {car_name}\nThis may take 10-15 seconds",
+            "Subaru",
+            DOMAIN,
+        )
     _LOGGER.debug("Sending %s command command to %s", cmd, car_name)
     success = False
     err_msg = ""
@@ -62,9 +63,11 @@ async def async_call_remote_service(
     except SubaruException as err:
         err_msg = err.message
 
-    hass.components.persistent_notification.dismiss(DOMAIN)
+    if notify in [NotificationOptions.PENDING, NotificationOptions.SUCCESS]:
+        hass.components.persistent_notification.dismiss(DOMAIN)
+
     if success:
-        if persist_notification:
+        if notify == NotificationOptions.SUCCESS:
             hass.components.persistent_notification.create(
                 f"{cmd} command successfully completed for {car_name}", "Subaru",
             )

--- a/custom_components/subaru/remote_service.py
+++ b/custom_components/subaru/remote_service.py
@@ -38,7 +38,9 @@ SERVICES_THAT_NEED_FETCH = [
 ]
 
 
-async def async_call_remote_service(hass, controller, cmd, vehicle_info):
+async def async_call_remote_service(
+    hass, controller, cmd, vehicle_info, persist_notification
+):
     """Execute subarulink remote command with start/end notification."""
     car_name = vehicle_info[VEHICLE_NAME]
     vin = vehicle_info[VEHICLE_VIN]
@@ -62,9 +64,10 @@ async def async_call_remote_service(hass, controller, cmd, vehicle_info):
 
     hass.components.persistent_notification.dismiss(DOMAIN)
     if success:
-        hass.components.persistent_notification.create(
-            f"{cmd} command successfully completed for {car_name}", "Subaru",
-        )
+        if persist_notification:
+            hass.components.persistent_notification.create(
+                f"{cmd} command successfully completed for {car_name}", "Subaru",
+            )
         _LOGGER.debug("%s command successfully completed for %s", cmd, car_name)
         return True
 

--- a/custom_components/subaru/strings.json
+++ b/custom_components/subaru/strings.json
@@ -33,9 +33,10 @@
     "step": {
       "init": {
         "title": "Subaru Starlink Options",
-        "description": "When enabled, vehicle polling will send a remote command to your vehicle every 2 hours to obtain new sensor data. Without vehicle polling, new sensor data is only received when the vehicle automatically pushes data (normally after engine shutdown).",
+        "description": "See documentation at: https://github.com/G-Two/homeassistant-subaru#options",
         "data": {
-          "update_enabled": "Enable vehicle polling"
+          "update_enabled": "Enable vehicle polling",
+          "persistent_notifications": "Enable persistent notifications for remote commands"
         }
       }
     }

--- a/custom_components/subaru/strings.json
+++ b/custom_components/subaru/strings.json
@@ -35,8 +35,8 @@
         "title": "Subaru Starlink Options",
         "description": "See documentation at: https://github.com/G-Two/homeassistant-subaru#options",
         "data": {
-          "update_enabled": "Enable vehicle polling",
-          "persistent_notifications": "Enable persistent notifications for remote commands"
+          "update_enabled": "Enable vehicle polling (CAUTION: May drain battery after weeks of non-driving)",
+          "notification_option": "Lovelace UI notifications for remote commands"
         }
       }
     }

--- a/custom_components/subaru/translations/en.json
+++ b/custom_components/subaru/translations/en.json
@@ -37,8 +37,8 @@
             "title": "Subaru Starlink Options",
             "description": "See documentation at: https://github.com/G-Two/homeassistant-subaru#options",
             "data": {
-              "update_enabled": "Enable vehicle polling",
-              "persistent_notifications": "Enable persistent notifications for remote commands"
+              "update_enabled": "Enable vehicle polling (CAUTION: May drain battery after weeks of non-driving)",
+              "notification_option": "Lovelace UI notifications for remote commands"
             }
           }
         }

--- a/custom_components/subaru/translations/en.json
+++ b/custom_components/subaru/translations/en.json
@@ -35,11 +35,12 @@
         "step": {
           "init": {
             "title": "Subaru Starlink Options",
-            "description": "When enabled, vehicle polling will send a remote command to your vehicle every 2 hours to obtain new sensor data. Without vehicle polling, new sensor data is only received when the vehicle automatically pushes data (normally after engine shutdown).",
+            "description": "See documentation at: https://github.com/G-Two/homeassistant-subaru#options",
             "data": {
-              "update_enabled": "Enable vehicle polling"
-                }
+              "update_enabled": "Enable vehicle polling",
+              "persistent_notifications": "Enable persistent notifications for remote commands"
             }
+          }
         }
     }
 }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,4 +2,4 @@ flake8
 pytest
 pytest-cov
 pytest-homeassistant-custom-component
-subarulink==0.3.15
+subarulink==0.3.16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from subarulink.const import COUNTRY_USA
 
 from custom_components.subaru.const import (
     CONF_COUNTRY,
-    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_NOTIFICATION_OPTION,
     CONF_UPDATE_ENABLED,
     DOMAIN,
     FETCH_INTERVAL,
@@ -22,6 +22,7 @@ from custom_components.subaru.const import (
     VEHICLE_HAS_REMOTE_START,
     VEHICLE_HAS_SAFETY_SERVICE,
     VEHICLE_NAME,
+    NotificationOptions,
 )
 from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -69,7 +70,7 @@ TEST_CONFIG = {
 
 TEST_OPTIONS = {
     CONF_UPDATE_ENABLED: True,
-    CONF_PERSISTENT_NOTIFICATIONS: True,
+    CONF_NOTIFICATION_OPTION: NotificationOptions.SUCCESS.value,
 }
 
 TEST_ENTITY_ID = "sensor.test_vehicle_2_odometer"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from subarulink.const import COUNTRY_USA
 
 from custom_components.subaru.const import (
     CONF_COUNTRY,
+    CONF_PERSISTENT_NOTIFICATIONS,
     CONF_UPDATE_ENABLED,
     DOMAIN,
     FETCH_INTERVAL,
@@ -68,6 +69,7 @@ TEST_CONFIG = {
 
 TEST_OPTIONS = {
     CONF_UPDATE_ENABLED: True,
+    CONF_PERSISTENT_NOTIFICATIONS: True,
 }
 
 TEST_ENTITY_ID = "sensor.test_vehicle_2_odometer"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,11 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from subarulink.exceptions import InvalidCredentials, InvalidPIN, SubaruException
 
 from custom_components.subaru import config_flow
-from custom_components.subaru.const import CONF_UPDATE_ENABLED, DOMAIN
+from custom_components.subaru.const import (
+    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_UPDATE_ENABLED,
+    DOMAIN,
+)
 from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE_ID, CONF_PIN
 from homeassistant.setup import async_setup_component
@@ -29,7 +33,6 @@ ASYNC_SETUP_ENTRY = "custom_components.subaru.async_setup_entry"
 
 
 async def test_user_init_form(user_form):
-    """Test the initial user form for first step of the config flow."""
     """Test the initial user form for first step of the config flow."""
     assert user_form["description_placeholders"] is None
     assert user_form["errors"] is None
@@ -173,10 +176,12 @@ async def test_pin_form_incorrect_pin(hass, pin_form):
 async def test_option_flow(hass, options_form):
     """Test config flow options."""
     result = await hass.config_entries.options.async_configure(
-        options_form["flow_id"], user_input={CONF_UPDATE_ENABLED: False},
+        options_form["flow_id"],
+        user_input={CONF_PERSISTENT_NOTIFICATIONS: False, CONF_UPDATE_ENABLED: False},
     )
     assert result["type"] == "create_entry"
     assert result["data"] == {
+        CONF_PERSISTENT_NOTIFICATIONS: False,
         CONF_UPDATE_ENABLED: False,
     }
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,9 +9,10 @@ from subarulink.exceptions import InvalidCredentials, InvalidPIN, SubaruExceptio
 
 from custom_components.subaru import config_flow
 from custom_components.subaru.const import (
-    CONF_PERSISTENT_NOTIFICATIONS,
+    CONF_NOTIFICATION_OPTION,
     CONF_UPDATE_ENABLED,
     DOMAIN,
+    NotificationOptions,
 )
 from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE_ID, CONF_PIN
@@ -177,11 +178,14 @@ async def test_option_flow(hass, options_form):
     """Test config flow options."""
     result = await hass.config_entries.options.async_configure(
         options_form["flow_id"],
-        user_input={CONF_PERSISTENT_NOTIFICATIONS: False, CONF_UPDATE_ENABLED: False},
+        user_input={
+            CONF_NOTIFICATION_OPTION: NotificationOptions.PENDING.value,
+            CONF_UPDATE_ENABLED: False,
+        },
     )
     assert result["type"] == "create_entry"
     assert result["data"] == {
-        CONF_PERSISTENT_NOTIFICATIONS: False,
+        CONF_NOTIFICATION_OPTION: NotificationOptions.PENDING.value,
         CONF_UPDATE_ENABLED: False,
     }
 


### PR DESCRIPTION
**Breaking Changes**
- Remote command status notifications are now disabled by default. Users that depend on notifications for automations or scripts may reenable them in the integration options. See [documentation](https://github.com/G-Two/homeassistant-subaru#readme) for more information. 
- `sensor.<name>_ev_time_to_full_charge` now defaults to epoch (1970-01-01T00:00:00) instead of "Unavailable" when vehicle is not charging.

**Feature Additions**
- Add configuration option for remote command Lovelace notifications. Closes #20.
  - Failure — Only notify on failure
  - Pending — Temporary notification of remote command in progress
  - Success — Persistent notification of completed remote command
