### PR TITLE
Add Events for async_call_remote_service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Users that desire full functionality should continue to use this custom componen
 * [Configuration](#configuration)
 * [Options](#options)
 * [Services](#services)
+* [Events](#events)
 
 ## Description
 The Subaru integration retrieves information provided by Subaru connected vehicle services.  Before using this integration, you must first register and have login credentials to [MySubaru](https://www.mysubaru.com).
@@ -162,3 +163,39 @@ data:
 There are 3 pre-configured Subaru climate presets, **Auto** (not available for EVs), **Full Cool**, and **Full Heat**. In addition you may configure up to 4 additional custom presets from the MySubaru website or the
 official mobile app. Although the underlying subarulink python package does support the creation of new presets, that functionality has not yet been implemented in this
 integration.
+
+## Events
+
+### subaru_command_sent
+
+This event is fired when a command is called.
+
+| Field      | Description                                                    |
+|------------|----------------------------------------------------------------|
+| `command`  | The command that was called. See [Command list](#command-list) |
+| `car_name` | The name of the vehicle                                        |
+
+### subaru_command_successful
+
+This event is fired when a command is successful.
+
+| Field      | Description                                                    |
+|------------|----------------------------------------------------------------|
+| `command`  | The command that was called. See [Command list](#command-list) |
+| `car_name` | The name of the vehicle                                        |
+
+### subaru_command_failed
+
+This event is fired when a command fails.
+
+| Field      | Description                                                    |
+|------------|----------------------------------------------------------------|
+| `command`  | The command that was called. See [Command list](#command-list) |
+| `car_name` | The name of the vehicle                                        |
+| `message`  | The message returned from the failed command                   |
+
+### Command List
+
+This is a list of possible commands for the above events.
+
+`fetch`, `update`, `lock`, `unlock`, `lights`, `lights_stop`, `horn`, `horn_stop`, `remote_start`, `remote_stop`, `charge_start`, `preset_name`

--- a/custom_components/subaru/const.py
+++ b/custom_components/subaru/const.py
@@ -17,6 +17,11 @@ ENTRY_COORDINATOR = "coordinator"
 ENTRY_VEHICLES = "vehicles"
 ENTRY_LISTENER = "listener"
 
+# events
+EVENT_SUBARU_COMMAND_SENT = "subaru_command_sent"
+EVENT_SUBARU_COMMAND_SUCCESS = "subaru_command_successful"
+EVENT_SUBARU_COMMAND_FAIL = "subaru_command_failed"
+
 # update coordinator name
 COORDINATOR_NAME = "subaru_data"
 

--- a/custom_components/subaru/remote_service.py
+++ b/custom_components/subaru/remote_service.py
@@ -13,6 +13,9 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
     DOMAIN,
+    EVENT_SUBARU_COMMAND_FAIL,
+    EVENT_SUBARU_COMMAND_SENT,
+    EVENT_SUBARU_COMMAND_SUCCESS,
     FETCH_INTERVAL,
     REMOTE_SERVICE_CHARGE_START,
     REMOTE_SERVICE_POLL_VEHICLE,
@@ -25,9 +28,6 @@ from .const import (
     VEHICLE_LAST_UPDATE,
     VEHICLE_NAME,
     VEHICLE_VIN,
-    EVENT_SUBARU_COMMAND_SENT,
-    EVENT_SUBARU_COMMAND_SUCCESS,
-    EVENT_SUBARU_COMMAND_FAIL,
 )
 from .options import NotificationOptions
 
@@ -59,7 +59,9 @@ async def async_call_remote_service(
             "Subaru",
             DOMAIN,
         )
-    hass.bus.async_fire(EVENT_SUBARU_COMMAND_SENT, {"command": cmd, "car_name": car_name})
+    hass.bus.async_fire(
+        EVENT_SUBARU_COMMAND_SENT, {"command": cmd, "car_name": car_name}
+    )
     _LOGGER.debug("Sending %s command command to %s", cmd, car_name)
     success = False
     err_msg = ""
@@ -88,7 +90,9 @@ async def async_call_remote_service(
                 f"{cmd} command successfully completed for {car_name}",
                 "Subaru",
             )
-        hass.bus.async_fire(EVENT_SUBARU_COMMAND_SUCCESS, {"command": cmd, "car_name": car_name})
+        hass.bus.async_fire(
+            EVENT_SUBARU_COMMAND_SUCCESS, {"command": cmd, "car_name": car_name}
+        )
         _LOGGER.debug("%s command successfully completed for %s", cmd, car_name)
         return
 
@@ -96,7 +100,10 @@ async def async_call_remote_service(
         hass.components.persistent_notification.create(
             f"{cmd} command failed for {car_name}: {err_msg}", "Subaru"
         )
-    hass.bus.async_fire(EVENT_SUBARU_COMMAND_FAIL, {"command": cmd, "car_name": car_name, "message": err_msg})
+    hass.bus.async_fire(
+        EVENT_SUBARU_COMMAND_FAIL,
+        {"command": cmd, "car_name": car_name, "message": err_msg},
+    )
     raise HomeAssistantError(f"Service {cmd} failed for {car_name}: {err_msg}")
 
 

--- a/custom_components/subaru/remote_service.py
+++ b/custom_components/subaru/remote_service.py
@@ -25,6 +25,9 @@ from .const import (
     VEHICLE_LAST_UPDATE,
     VEHICLE_NAME,
     VEHICLE_VIN,
+    EVENT_SUBARU_COMMAND_SENT,
+    EVENT_SUBARU_COMMAND_SUCCESS,
+    EVENT_SUBARU_COMMAND_FAIL,
 )
 from .options import NotificationOptions
 
@@ -56,6 +59,7 @@ async def async_call_remote_service(
             "Subaru",
             DOMAIN,
         )
+    hass.bus.async_fire(EVENT_SUBARU_COMMAND_SENT, {"command": cmd, "car_name": car_name})
     _LOGGER.debug("Sending %s command command to %s", cmd, car_name)
     success = False
     err_msg = ""
@@ -84,6 +88,7 @@ async def async_call_remote_service(
                 f"{cmd} command successfully completed for {car_name}",
                 "Subaru",
             )
+        hass.bus.async_fire(EVENT_SUBARU_COMMAND_SUCCESS, {"command": cmd, "car_name": car_name})
         _LOGGER.debug("%s command successfully completed for %s", cmd, car_name)
         return
 
@@ -91,6 +96,7 @@ async def async_call_remote_service(
         hass.components.persistent_notification.create(
             f"{cmd} command failed for {car_name}: {err_msg}", "Subaru"
         )
+    hass.bus.async_fire(EVENT_SUBARU_COMMAND_FAIL, {"command": cmd, "car_name": car_name, "message": err_msg})
     raise HomeAssistantError(f"Service {cmd} failed for {car_name}: {err_msg}")
 
 


### PR DESCRIPTION
Home Assistant 2023.6 changed persistent notifications to no longer be entities.
Before 2023.6, I had automations that were triggered by the creation of these notifications to create additional notifications and other actions from the events from this integration.

I created this PR to add events so these automations can be retained.

- `subaru_command_sent` - data: `{command, car_name}`
- `subaru_command_successful` - data: `{command, car_name}`
- `subaru_command_failed` - data: `{command, car_name, message}`
