### PR TITLE
Add launch configuration for debugging Home Assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !.github/
 !.github/**
 !.vscode/
+!.vscode/launch.json
 !.vscode/tasks.json
 !.vscode/settings.json
 !custom_components/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Home Assistant",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "homeassistant",
+            "justMyCode": false,
+            "args": [
+                "--debug",
+                "-c",
+                "/config"
+            ],
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/custom_components/subaru",
+                    "remoteRoot": "/config/custom_components/subaru"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I had to debug an issue with my setup, and ended up finding how to setup VSCode to do breakpoint debugging with a custom component. I didn't find other documentation about this in the official forums, so I just thought about contributing this back.

The key here is how to do pathMappings.

Home Assistant needs to be started with `--debug`. This can be either with flag like in this PR, or we could also add `debugpy:` to `~/.devcontainer/configuration.yaml.DEFAULT` and just use regular "Attach local" from https://github.com/home-assistant/core/blob/31f98c12af4916595a3906c9bb416f84f17d15c0/.vscode/launch.json#L55.