### PR TITLE
v0.7.23

### DIFF
--- a/custom_components/subaru/binary_sensor.py
+++ b/custom_components/subaru/binary_sensor.py
@@ -170,27 +170,27 @@ LOCK_BINARY_SENSORS = [
     BinarySensorEntityDescription(
         name="Trunk lock",
         key=sc.LOCK_BOOT_STATUS,
-        device_class=BinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.LOCK,
     ),
     BinarySensorEntityDescription(
         name="Front left door lock",
         key=sc.LOCK_FRONT_LEFT_STATUS,
-        device_class=BinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.LOCK,
     ),
     BinarySensorEntityDescription(
         name="Front right door lock",
         key=sc.LOCK_FRONT_RIGHT_STATUS,
-        device_class=BinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.LOCK,
     ),
     BinarySensorEntityDescription(
         name="Rear left door lock",
         key=sc.LOCK_REAR_LEFT_STATUS,
-        device_class=BinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.LOCK,
     ),
     BinarySensorEntityDescription(
         name="Rear right door lock",
         key=sc.LOCK_REAR_RIGHT_STATUS,
-        device_class=BinarySensorDeviceClass.DOOR,
+        device_class=BinarySensorDeviceClass.LOCK,
     ),
 ]
 

--- a/custom_components/subaru/device_tracker.py
+++ b/custom_components/subaru/device_tracker.py
@@ -6,8 +6,7 @@ from typing import Any
 
 from subarulink.const import LATITUDE, LONGITUDE, TIMESTAMP
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/subaru/lock.py
+++ b/custom_components/subaru/lock.py
@@ -199,6 +199,7 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send the unlock command."""
         _LOGGER.debug("Unlocking doors for: %s", self.car_name)
+        self._cancel_pending_verify()
         if self.lock_status_available:
             self._attr_is_unlocking = True
             self.async_write_ha_state()
@@ -217,9 +218,9 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
             self.coordinator.async_update_listeners()
             raise HomeAssistantError("Failed to unlock doors") from err
         if self.lock_status_available:
+            self._attr_is_unlocking = False
             self._schedule_unlock_verify()
-        else:
-            self.coordinator.async_update_listeners()
+        self.coordinator.async_update_listeners()
 
     @property
     def is_locked(self) -> bool | None:
@@ -261,6 +262,7 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
     async def async_unlock_specific_door(self, door: str) -> None:
         """Send the unlock command for a specified door."""
         _LOGGER.debug("Unlocking %s door for: %s", self, self.car_name)
+        self._cancel_pending_verify()
         if self.lock_status_available:
             self._attr_is_unlocking = True
             self.async_write_ha_state()
@@ -279,6 +281,6 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
             self.coordinator.async_update_listeners()
             raise HomeAssistantError("Failed to unlock doors") from err
         if self.lock_status_available:
+            self._attr_is_unlocking = False
             self._schedule_unlock_verify()
-        else:
-            self.coordinator.async_update_listeners()
+        self.coordinator.async_update_listeners()

--- a/custom_components/subaru/lock.py
+++ b/custom_components/subaru/lock.py
@@ -12,17 +12,20 @@ from subarulink.const import (
     LOCK_LOCKED,
     LOCK_REAR_LEFT_STATUS,
     LOCK_REAR_RIGHT_STATUS,
+    LOCK_UNKNOWN,
 )
 from subarulink.controller import Controller
+from subarulink.exceptions import SubaruException
 import voluptuous as vol
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import SERVICE_LOCK, SERVICE_UNLOCK
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -45,7 +48,19 @@ from .const import (
     VEHICLE_VIN,
 )
 from .device import get_device_info
-from .remote_service import async_call_remote_service
+from .remote_service import async_call_remote_service, poll_subaru, refresh_subaru
+
+# Vehicle auto-relocks ~30s after a remote unlock if no door is opened.
+# Poll past that window to capture the final post-relock state.
+UNLOCK_VERIFY_DELAY_SEC = 45
+
+LOCK_DOORS = (
+    LOCK_BOOT_STATUS,
+    LOCK_FRONT_LEFT_STATUS,
+    LOCK_FRONT_RIGHT_STATUS,
+    LOCK_REAR_LEFT_STATUS,
+    LOCK_REAR_RIGHT_STATUS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,10 +119,54 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
         self.lock_status_available = self.vehicle_info[VEHICLE_HAS_LOCK_STATUS]
         self._attr_unique_id = f"{self.vin}_door_locks"
         self._attr_device_info = get_device_info(vehicle_info)
+        self._verify_cancel: CALLBACK_TYPE | None = None
+        self._verify_job = HassJob(
+            self._verify_lock_state,
+            name=f"subaru_lock_verify_{self.vin}",
+            cancel_on_shutdown=True,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register cleanup of any pending verify-poll timer."""
+        await super().async_added_to_hass()
+        self.async_on_remove(self._cancel_pending_verify)
+
+    @callback
+    def _cancel_pending_verify(self) -> None:
+        """Cancel a pending delayed verify poll, if any."""
+        if self._verify_cancel is not None:
+            self._verify_cancel()
+            self._verify_cancel = None
+
+    async def _verify_lock_state(self, _: Any = None) -> None:
+        """Force a vehicle poll to resolve the true lock state."""
+        self._verify_cancel = None
+        _LOGGER.debug("Verifying lock state for %s via vehicle poll", self.car_name)
+        try:
+            await poll_subaru(self.vehicle_info, self.controller, update_interval=0)
+            await refresh_subaru(self.vehicle_info, self.controller, refresh_interval=0)
+        except SubaruException as err:
+            _LOGGER.warning(
+                "Lock state verification poll failed for %s: %s",
+                self.car_name,
+                err.message,
+            )
+        if self.lock_status_available:
+            self._attr_is_locking = False
+            self._attr_is_unlocking = False
+        self.coordinator.async_update_listeners()
+
+    def _schedule_unlock_verify(self) -> None:
+        """Schedule a delayed poll past the auto-relock window."""
+        self._cancel_pending_verify()
+        self._verify_cancel = async_call_later(
+            self.hass, UNLOCK_VERIFY_DELAY_SEC, self._verify_job
+        )
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Send the lock command."""
         _LOGGER.debug("Locking doors for: %s", self.car_name)
+        self._cancel_pending_verify()
         if self.lock_status_available:
             self._attr_is_locking = True
             self.async_write_ha_state()
@@ -121,8 +180,18 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
                 self.config_entry.options.get(CONF_NOTIFICATION_OPTION),
             )
         except HomeAssistantError as err:
+            if self.lock_status_available:
+                self._attr_is_locking = False
+            self.coordinator.async_update_listeners()
             raise HomeAssistantError("Failed to lock doors") from err
-        finally:
+        # is_locked reads coordinator.data[vin][VEHICLE_STATUS], which is the
+        # same dict reference as subarulink's internal cache (returned by
+        # controller.get_data and never copied). The fetch inside
+        # async_call_remote_service mutates that cache in place, so this check
+        # sees fresh post-command state without an explicit coordinator refresh.
+        if self.lock_status_available and self.is_locked is None:
+            await self._verify_lock_state()
+        else:
             if self.lock_status_available:
                 self._attr_is_locking = False
             self.coordinator.async_update_listeners()
@@ -143,33 +212,27 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
                 self.config_entry.options.get(CONF_NOTIFICATION_OPTION),
             )
         except HomeAssistantError as err:
-            raise HomeAssistantError("Failed to unlock doors") from err
-        finally:
             if self.lock_status_available:
                 self._attr_is_unlocking = False
+            self.coordinator.async_update_listeners()
+            raise HomeAssistantError("Failed to unlock doors") from err
+        if self.lock_status_available:
+            self._schedule_unlock_verify()
+        else:
             self.coordinator.async_update_listeners()
 
     @property
     def is_locked(self) -> bool | None:
-        """Return true if all doors are locked."""
-        if self.lock_status_available:
-            if self.vin not in self.coordinator.data:
-                return None
-            for door in [
-                LOCK_BOOT_STATUS,
-                LOCK_FRONT_LEFT_STATUS,
-                LOCK_FRONT_RIGHT_STATUS,
-                LOCK_REAR_LEFT_STATUS,
-                LOCK_REAR_RIGHT_STATUS,
-            ]:
-                if (
-                    self.coordinator.data[self.vin][VEHICLE_STATUS].get(door)
-                    == LOCK_LOCKED
-                ):
-                    continue
-                return False
-            return True
-        return None
+        """Return true if all doors are locked, None if any door is unknown."""
+        if not self.lock_status_available:
+            return None
+        if self.vin not in self.coordinator.data:
+            return None
+        status = self.coordinator.data[self.vin][VEHICLE_STATUS]
+        states = [status.get(door) for door in LOCK_DOORS]
+        if any(s is None or s == LOCK_UNKNOWN for s in states):
+            return None
+        return all(s == LOCK_LOCKED for s in states)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -211,8 +274,11 @@ class SubaruLock(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], LockE
                 self.config_entry.options.get(CONF_NOTIFICATION_OPTION),
             )
         except HomeAssistantError as err:
-            raise HomeAssistantError("Failed to unlock doors") from err
-        finally:
             if self.lock_status_available:
                 self._attr_is_unlocking = False
+            self.coordinator.async_update_listeners()
+            raise HomeAssistantError("Failed to unlock doors") from err
+        if self.lock_status_available:
+            self._schedule_unlock_verify()
+        else:
             self.coordinator.async_update_listeners()

--- a/custom_components/subaru/manifest.json
+++ b/custom_components/subaru/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/G-Two/homeassistant-subaru/issues",
   "requirements": [
-    "subarulink==0.7.21rc0"
+    "subarulink==0.7.21rc1"
   ],
   "version": "0.7.23rc1"
 }

--- a/custom_components/subaru/remote_service.py
+++ b/custom_components/subaru/remote_service.py
@@ -109,7 +109,7 @@ async def poll_subaru(vehicle, controller, update_interval=UPDATE_INTERVAL):
     last_update = vehicle[VEHICLE_LAST_UPDATE]
     success = False
 
-    if (cur_time - last_update) > update_interval:
+    if (cur_time - last_update) >= update_interval:
         success = await controller.update(vehicle[VEHICLE_VIN], force=True)
         vehicle[VEHICLE_LAST_UPDATE] = cur_time
 
@@ -125,7 +125,7 @@ async def refresh_subaru(
     vin = vehicle[VEHICLE_VIN]
     success = False
 
-    if (cur_time - last_fetch) > refresh_interval:
+    if (cur_time - last_fetch) >= refresh_interval:
         success = await controller.fetch(vin, force=True)
         vehicle[VEHICLE_LAST_FETCH] = cur_time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ test = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-homeassistant-custom-component>=0.13.334",
-    "subarulink==0.7.21rc0"
+    "subarulink==0.7.21rc1"
 ]
 dev = [
     "black>=24.0.0",

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -10,6 +10,7 @@ from subarulink.const import (
     LOCK_REAR_LEFT_STATUS,
     LOCK_REAR_RIGHT_STATUS,
 )
+from subarulink.exceptions import SubaruException
 
 from custom_components.subaru.const import (
     ATTR_DOOR,
@@ -19,18 +20,21 @@ from custom_components.subaru.const import (
     UNLOCK_DOOR_DRIVERS,
     VEHICLE_STATUS,
 )
+from custom_components.subaru.lock import UNLOCK_VERIFY_DELAY_SEC
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .api_responses import TEST_VIN_2_EV
-from .conftest import MOCK_API
+from .api_responses import TEST_VIN_1_G1, TEST_VIN_2_EV, VEHICLE_DATA
+from .conftest import MOCK_API, advance_time, setup_subaru_config_entry
 
 MOCK_API_FETCH = f"{MOCK_API}fetch"
 MOCK_API_LOCK = f"{MOCK_API}lock"
 MOCK_API_UNLOCK = f"{MOCK_API}unlock"
+MOCK_API_UPDATE = f"{MOCK_API}update"
 DEVICE_ID = "lock.test_vehicle_2_door_locks"
+G1_DEVICE_ID = "lock.test_vehicle_1_door_locks"
 
 
 async def test_device_exists(hass, entity_registry: er.EntityRegistry, ev_entry):
@@ -175,6 +179,228 @@ async def test_is_locked_one_door_unlocked(hass, ev_entry):
     lock_entity = hass.data["entity_components"][LOCK_DOMAIN].get_entity(DEVICE_ID)
     assert lock_entity is not None
     assert lock_entity.is_locked is False
+
+
+async def test_is_locked_any_door_unknown(hass, ev_entry):
+    """Test is_locked returns None when any door reports UNKNOWN."""
+    coordinator = hass.data[SUBARU_DOMAIN][ev_entry.entry_id][ENTRY_COORDINATOR]
+    status = coordinator.data[TEST_VIN_2_EV][VEHICLE_STATUS]
+    for door in ALL_LOCK_DOORS:
+        status[door] = "LOCKED"
+    status[LOCK_BOOT_STATUS] = "UNKNOWN"
+
+    lock_entity = hass.data["entity_components"][LOCK_DOMAIN].get_entity(DEVICE_ID)
+    assert lock_entity is not None
+    assert lock_entity.is_locked is None
+
+
+async def test_lock_polls_vehicle_when_state_unknown(hass, ev_entry):
+    """Test that the lock command issues a vehicle poll when state is still unknown after refresh."""
+    coordinator = hass.data[SUBARU_DOMAIN][ev_entry.entry_id][ENTRY_COORDINATOR]
+    status = coordinator.data[TEST_VIN_2_EV][VEHICLE_STATUS]
+    for door in ALL_LOCK_DOORS:
+        status[door] = "UNKNOWN"
+
+    with (
+        patch(MOCK_API_LOCK) as mock_lock,
+        patch(MOCK_API_FETCH) as mock_fetch,
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+        mock_lock.assert_called_once()
+        mock_update.assert_called_once()
+        assert mock_fetch.call_count == 2
+
+
+async def test_lock_does_not_poll_when_state_known(hass, ev_entry):
+    """Test that the lock command does not extra-poll when the state is already known."""
+    coordinator = hass.data[SUBARU_DOMAIN][ev_entry.entry_id][ENTRY_COORDINATOR]
+    status = coordinator.data[TEST_VIN_2_EV][VEHICLE_STATUS]
+    for door in ALL_LOCK_DOORS:
+        status[door] = "LOCKED"
+
+    with (
+        patch(MOCK_API_LOCK) as mock_lock,
+        patch(MOCK_API_FETCH) as mock_fetch,
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+        mock_lock.assert_called_once()
+        mock_fetch.assert_called_once()
+        mock_update.assert_not_called()
+
+
+async def test_unlock_schedules_delayed_verify_poll(hass, ev_entry):
+    """Test that unlock schedules a delayed poll past the auto-relock window."""
+    with (
+        patch(MOCK_API_UNLOCK) as mock_unlock,
+        patch(MOCK_API_FETCH) as mock_fetch,
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+        mock_unlock.assert_called_once()
+        # Immediate post-command refresh only; no extra poll yet
+        mock_fetch.assert_called_once()
+        mock_update.assert_not_called()
+
+        # After the auto-relock window, the scheduled verify poll fires
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+        mock_update.assert_called_once()
+        assert mock_fetch.call_count == 2
+
+
+async def test_unlock_specific_door_schedules_delayed_verify_poll(hass, ev_entry):
+    """Test that unlock_specific_door also schedules the delayed verify poll."""
+    with (
+        patch(MOCK_API_UNLOCK) as mock_unlock,
+        patch(MOCK_API_FETCH) as mock_fetch,
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            SUBARU_DOMAIN,
+            SERVICE_UNLOCK_SPECIFIC_DOOR,
+            {ATTR_ENTITY_ID: DEVICE_ID, ATTR_DOOR: UNLOCK_DOOR_DRIVERS},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_unlock.assert_called_once()
+        mock_update.assert_not_called()
+
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+        mock_update.assert_called_once()
+        assert mock_fetch.call_count == 2
+
+
+async def test_unlock_failure_does_not_schedule_verify_poll(hass, ev_entry):
+    """Test that a failed unlock command does not schedule a verify poll."""
+    with (
+        patch(MOCK_API_UNLOCK, return_value=False),
+        patch(MOCK_API_FETCH),
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        with raises(HomeAssistantError):
+            await hass.services.async_call(
+                LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+            )
+            await hass.async_block_till_done()
+
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+        mock_update.assert_not_called()
+
+
+async def test_verify_poll_handles_subaru_exception(hass, ev_entry, caplog):
+    """Test that a SubaruException during the verify poll is caught and logged."""
+    with (
+        patch(MOCK_API_UNLOCK),
+        patch(MOCK_API_FETCH),
+        patch(MOCK_API_UPDATE, side_effect=SubaruException("poll failed")),
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+
+    assert "Lock state verification poll failed" in caplog.text
+    assert "poll failed" in caplog.text
+
+
+async def test_unlock_without_lock_status_notifies_listeners(
+    hass, subaru_config_entry, enable_custom_integrations
+):
+    """Test unlock on a vehicle without lock status reporting notifies listeners without scheduling a verify poll."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_1_G1],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1],
+    )
+    with (
+        patch(MOCK_API_UNLOCK) as mock_unlock,
+        patch(MOCK_API_FETCH) as mock_fetch,
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: G1_DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+        mock_unlock.assert_called_once()
+        # Single refresh from the command itself; no verify scheduled
+        mock_fetch.assert_called_once()
+
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+        mock_update.assert_not_called()
+        assert mock_fetch.call_count == 1
+
+
+async def test_unlock_specific_door_without_lock_status_notifies_listeners(
+    hass, subaru_config_entry, enable_custom_integrations
+):
+    """Test unlock_specific_door on a vehicle without lock status reporting notifies listeners without scheduling a verify poll."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_1_G1],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1],
+    )
+    with (
+        patch(MOCK_API_UNLOCK) as mock_unlock,
+        patch(MOCK_API_FETCH) as mock_fetch,
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            SUBARU_DOMAIN,
+            SERVICE_UNLOCK_SPECIFIC_DOOR,
+            {ATTR_ENTITY_ID: G1_DEVICE_ID, ATTR_DOOR: UNLOCK_DOOR_DRIVERS},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_unlock.assert_called_once()
+        mock_fetch.assert_called_once()
+
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+        mock_update.assert_not_called()
+        assert mock_fetch.call_count == 1
+
+
+async def test_repeated_unlock_replaces_pending_verify_poll(hass, ev_entry):
+    """Test that issuing another unlock cancels the prior pending verify poll."""
+    with (
+        patch(MOCK_API_UNLOCK),
+        patch(MOCK_API_FETCH),
+        patch(MOCK_API_UPDATE) as mock_update,
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+
+        # Re-issue the unlock before the first scheduled verify fires
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: DEVICE_ID}, blocking=True
+        )
+        await hass.async_block_till_done()
+
+        advance_time(hass, UNLOCK_VERIFY_DELAY_SEC)
+        await hass.async_block_till_done()
+        # Only one verify poll should have fired (from the second unlock)
+        mock_update.assert_called_once()
 
 
 async def test_lock_state_follows_coordinator_update(hass, ev_entry):


### PR DESCRIPTION
- Remove import of deprecated alias TrackerEntity https://github.com/G-Two/homeassistant-subaru/issues/172
- Bump to subarulink v0.7.21rc1
  - Prevent sending remote climate heated/ventilated seat settings to vehicles that do not support it
    - Fixes "Full Cool" preset failing for certain vehicles https://github.com/G-Two/homeassistant-subaru/issues/130
  - Checks 240 minute session age for all API calls (not just remote commands)
    - Maybe fixes some HTTP 401 errors? https://github.com/G-Two/homeassistant-subaru/issues/169
  - Always update lock state (even if UNKNOWN)
    - Prevent stale locked/unlocked status when unknown https://github.com/G-Two/homeassistant-subaru/issues/163
- Fix device class for locks binary sensors (from door to lock)
- Check lock status after a remote lock command, if unknown, poll the vehicle to update the state
- Wait 45 seconds and unconditionally poll for lock status after a remote unlock command since there is an automatic relock 30 seconds after a remote unlock if no doors are opened
